### PR TITLE
Converted FeatureBox to a link and added hover effect

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.js
+++ b/src/components/common/FeatureBox/FeatureBox.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom/cjs/react-router-dom';
 import PropTypes from 'prop-types';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -7,18 +8,14 @@ import styles from './FeatureBox.module.scss';
 
 const FeatureBox = ({ active, icon, children, link }) => (
   <div className={styles.root + (active ? ' ' + styles.active : '')}>
-    <a
-      href={link}
-      className={styles.featurelink}
-      onClick={e => e.preventDefault()} //disabled click effect temporarily
-    >
+    <Link to={link} className={styles.featurelink}>
       {icon && (
         <div className={styles.iconWrapper}>
           <FontAwesomeIcon className={styles.icon} icon={icon} />
         </div>
       )}
       <div className={styles.content}>{children}</div>
-    </a>
+    </Link>
   </div>
 );
 

--- a/src/components/common/FeatureBox/FeatureBox.js
+++ b/src/components/common/FeatureBox/FeatureBox.js
@@ -5,14 +5,20 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './FeatureBox.module.scss';
 
-const FeatureBox = ({ active, icon, children }) => (
+const FeatureBox = ({ active, icon, children, link }) => (
   <div className={styles.root + (active ? ' ' + styles.active : '')}>
-    {icon && (
-      <div className={styles.iconWrapper}>
-        <FontAwesomeIcon className={styles.icon} icon={icon} />
-      </div>
-    )}
-    <div className={styles.content}>{children}</div>
+    <a
+      href={link}
+      className={styles.featurelink}
+      onClick={e => e.preventDefault()} //disabled click effect temporarily
+    >
+      {icon && (
+        <div className={styles.iconWrapper}>
+          <FontAwesomeIcon className={styles.icon} icon={icon} />
+        </div>
+      )}
+      <div className={styles.content}>{children}</div>
+    </a>
   </div>
 );
 
@@ -20,6 +26,7 @@ FeatureBox.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.object,
   active: PropTypes.bool,
+  link: PropTypes.string,
 };
 
 export default FeatureBox;

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -4,7 +4,7 @@
   text-decoration: none !important;
 }
 .root {
-  border: 1px solid #b6b6b6;
+  border: 1px solid $lighterGray;
   text-align: center;
   margin-top: 40px;
 
@@ -24,7 +24,7 @@
 
     &::before {
       content: "";
-      border: 1px solid #b6b6b6;
+      border: 1px solid $lighterGray;
       position: absolute;
       top: 50%;
       left: 50%;
@@ -32,7 +32,7 @@
       width: 76px;
       height: 76px;
       border-radius: 100%;
-      background-color: #ffffff;
+      background-color: $white;
       z-index: -1;
     }
 
@@ -45,14 +45,14 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      border: 1px solid #b6b6b6;
+      border: 1px solid $lighterGray;
       transition: 1.0s ease;
     }
   }
 
   .content {
     text-transform: uppercase;
-    color: rgb(42, 42, 42);
+    color: $darkGray;
     margin-top: -0.5rem;
     letter-spacing: 1px;
     font-weight: 300;

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -1,5 +1,8 @@
 @import "../../../styles/settings.scss";
 
+.featurelink{
+  text-decoration: none !important;
+}
 .root {
   border: 1px solid #b6b6b6;
   text-align: center;
@@ -12,6 +15,7 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
+    transition: 0.6s ease;
 
     .icon {
       position: relative;
@@ -42,6 +46,7 @@
       left: 50%;
       transform: translate(-50%, -50%);
       border: 1px solid #b6b6b6;
+      transition: 1.0s ease;
     }
   }
 
@@ -51,17 +56,32 @@
     margin-top: -0.5rem;
     letter-spacing: 1px;
     font-weight: 300;
+    transition: 0.3s ease;
 
     h5 {
       font-weight: 600;
       margin: 0;
     }
 
-    p {
-    }
   }
 
   &.active {
+    .iconWrapper {
+      color: #ffffff;
+
+      &::after {
+        background-color: $primary;
+        border-color: $primary;
+      }
+    }
+
+    .content {
+      color: $primary;
+    }
+  }
+
+  // Hover effect
+  &:hover {
     .iconWrapper {
       color: #ffffff;
 

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -67,7 +67,7 @@
 
   &.active {
     .iconWrapper {
-      color: #ffffff;
+      color: $white;
 
       &::after {
         background-color: $primary;
@@ -83,7 +83,7 @@
   // Hover effect
   &:hover {
     .iconWrapper {
-      color: #ffffff;
+      color: $white;
 
       &::after {
         background-color: $primary;

--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -16,25 +16,25 @@ const FeatureBoxes = () => (
     <div className='container'>
       <div className='row'>
         <div className='col'>
-          <FeatureBox icon={faTruck} active>
+          <FeatureBox icon={faTruck} active link='placeHolder'>
             <h5>Free shipping</h5>
             <p>All orders</p>
           </FeatureBox>
         </div>
         <div className='col'>
-          <FeatureBox icon={faHeadphones}>
+          <FeatureBox icon={faHeadphones} link='placeHolder'>
             <h5>24/7 customer</h5>
             <p>support</p>
           </FeatureBox>
         </div>
         <div className='col'>
-          <FeatureBox icon={faReplyAll}>
+          <FeatureBox icon={faReplyAll} link='placeHolder'>
             <h5>Money back</h5>
             <p>guarantee</p>
           </FeatureBox>
         </div>
         <div className='col'>
-          <FeatureBox icon={faBullhorn}>
+          <FeatureBox icon={faBullhorn} link='placeHolder'>
             <h5>Member discount</h5>
             <p>First order</p>
           </FeatureBox>

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -1,3 +1,5 @@
+$white: #ffffff;
+
 $base-padding: 24px;
 
 $header-topbar-bg: #434343;


### PR DESCRIPTION
FeatureBox.js:
Converted content of FeatureBox to be a clickable link. Link temporarily disabled so that is does not navigate to a different page.
Additionaly added a PropType to check the content of link and require a string.

FeatureBox.module.scss:
added styles for added link with !important to overwrite default underline on hover
added transition time and style for hover effect to: .root .iconWrapper and .content
added hover effect styles to match active state for the FeatureBox
deleted empty style for p that was causing a warning

FeatureBoxes.js:
added link prop. to FeatureBox with a placeholder for future implementation

JIRA ticket: 
https://projects.kodilla.com/browse/WDP240901-3